### PR TITLE
Workaround failures when installing uWSGI

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Install the LTS version of uwsgi
   pip:
-    name: https://projects.unbit.it/downloads/uwsgi-lts.tar.gz
+    name: http://projects.unbit.it/downloads/uwsgi-lts.tar.gz
 
 - name: Create uwsgi configuration dir for emperor mode
   file:


### PR DESCRIPTION
Failure before this change was:

   /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/packages/urllib3/util/ssl_.py:318: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/security.html#snimissingwarning.