### PR TITLE
Send logs from error.log and combine.log to kibana

### DIFF
--- a/roles/monitoring/templates/filebeat.yml
+++ b/roles/monitoring/templates/filebeat.yml
@@ -26,6 +26,17 @@ filebeat.inputs:
   ignore_older: 3h
 - type: log
   paths:
+    - /var/log/echaloasuerte-3/combined.log
+  fields:
+    logzio_codec: json
+    token: {{ logzio_token }}
+    type: echaloasuerte-3-nodejs-combined
+    env: {{ filebeat_env }}
+  fields_under_root: true
+  encoding: utf-8
+  ignore_older: 3h
+- type: log
+  paths:
     - /var/log/echaloasuerte-3/echaloasuerte-uwsgi*.log
   fields:
     logzio_codec: plain


### PR DESCRIPTION
I think the code deployed in the development server should have already create these two log files.

Not sure if that's the only change we need to make to send these logs to kibana. Let me know if I have to do something else.
