### PR TITLE
Revert "Disable SSR in eas3"

### DIFF
--- a/roles/echaloasuerte-3/templates/echaloasuerte-nginx.conf
+++ b/roles/echaloasuerte-3/templates/echaloasuerte-nginx.conf
@@ -17,7 +17,7 @@ server {
     }
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri @node;
     }
 
     location @node {


### PR DESCRIPTION
Reverts etcaterva/deployment#94

This is currently breaking things. To disable SSR we need to change the containers to start serving the npm-built files instead using `npm start`