### PR TITLE
Set docker replicas and memory limit

### DIFF
--- a/hosts_prod
+++ b/hosts_prod
@@ -5,6 +5,7 @@
 echaloasuerte_3_git_branch=prod
 echaloasuerte_git_branch=prod
 filebeat_env=prod
+echaloasuerte_3_replicas=2
 
 [POSTGRESQL_DATABASES]
 193.70.1.6 node_hostname=prod-ovh2

--- a/roles/echaloasuerte-3/tasks/main.yml
+++ b/roles/echaloasuerte-3/tasks/main.yml
@@ -121,6 +121,8 @@
       retries: 10
       start_period: 30s
     replicas: "{{ echaloasuerte_3_replicas }}"
+    limits:
+      memory: 300M
     env:
       LOGS_SUFFIX: "{{'{{.Task.Slot}}_{{.Task.ID}}'}}"
     publish:


### PR DESCRIPTION
Replicas so that if a container is somehow killed, there is another one to serve requests.

Memory limits so that if a container starts consuming lots of ram, it gets killed.