### PR TITLE
Serve ads.txt from express

### DIFF
--- a/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
+++ b/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
@@ -98,6 +98,11 @@ server {
         proxy_pass http://new-frontend;
     }
 
+    location /ads.txt {
+        proxy_set_header Host $http_host;
+        proxy_pass http://new-frontend;
+    }
+
     location /api {
         include         uwsgi_params;
         uwsgi_pass      backend-echaloasuerte-3;


### PR DESCRIPTION
Google adsense is complaining cause it can not find that file.

We are serving the file from express (see https://github.com/etcaterva/eas-frontend/commit/fa284eaccb064f0d96df6a0dedf908192e30e782)