### PR TITLE
Bump raffle to 100% and add redirect for old URL

### DIFF
--- a/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
+++ b/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
@@ -16,12 +16,6 @@ split_clients app"${remote_addr}${http_user_agent}${date_gmt}" $appversion {
     *       new-frontend;
 }
 
-map $cookie_raffle_split_test_version $upstream_group {
-    default $appversion;
-    "old-backend-frontend" "old-backend-frontend";
-    "new-frontend" "new-frontend";
-}
-
 server {
     listen localhost:8080;
 
@@ -39,6 +33,7 @@ server {
     rewrite ^/draw/new/groups/shared/?$ /groups/public permanent;
     rewrite ^/draw/new/coin/?$ /coin permanent;
     rewrite ^/draw/new/spinner/?$ /spinner permanent;
+    rewrite ^/draw/new/raffle/?$ /raffles permanent;
 
     location /static/ {
         root      {{ echaloasuerte_root }};
@@ -78,19 +73,19 @@ server {
         proxy_pass http://new-frontend;
     }
 
-    location /draw/new/raffle/ {
-        add_header Set-Cookie "raffle_split_test_version=$upstream_group;Path=/;Max-Age=518400;";
-        proxy_set_header Host $host;
+    location /raffles/ {
+        proxy_set_header Host $http_host;
+        proxy_pass http://new-frontend;
+    }
 
-        if ($upstream_group = "old-backend-frontend") {
-            proxy_pass http://old-backend-frontend;
-            break;
-        }
-        if ($upstream_group = "new-frontend") {
-            proxy_pass http://new-frontend;
-            break;
-        }
-        proxy_pass http://$appversion;
+    location /raffle/ {
+        proxy_set_header Host $http_host;
+        proxy_pass http://new-frontend;
+    }
+
+    location /facebook/ {
+        proxy_set_header Host $http_host;
+        proxy_pass http://new-frontend;
     }
 
     location /privacy-policy {


### PR DESCRIPTION
Before there was only one raffle url `/draw/new/raffle/` and the user could choose between normal and facebook raffle from a dropdown.
Now the main page when the user clicks on a raffle is `/raffles`, where the different types of raffles are listed (so far only normal and fb).
![image](https://user-images.githubusercontent.com/9324508/76160880-2f68ab00-612e-11ea-90e0-e88cec0193a4.png)

In the PR that we had to revert yesterday I forgot to add a route for that intermediate page (`/raffles`), thus the 404.