### PR TITLE
Expose NextJS static files

### DIFF
--- a/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
+++ b/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
@@ -46,6 +46,12 @@ server {
         expires 365d;
     }
 
+    location /_next/static/ {
+        root      {{ echaloasuerte_root }};
+        try_files $uri @node;
+        expires 365d;
+    }
+
     location /favicon.ico {
         try_files $uri @node;
         expires 365d;


### PR DESCRIPTION
when building the application, NextJS places the static files in`/_next/static`. Now all these request are 404ing