### PR TITLE
Rate limit API

### DIFF
--- a/roles/common/files/echaloasuerte.conf.jail
+++ b/roles/common/files/echaloasuerte.conf.jail
@@ -4,7 +4,7 @@ port     = http,https
 filter   = echaloasuerte-nginx
 logpath  = /var/log/nginx/access.log
 # 50 times on 1 minute
-maxretry = 50
+maxretry = 200
 findtime = 60
 # ban on 1 h
 bantime = 3600

--- a/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
+++ b/roles/echaloasuerte/templates/echaloasuerte-nginx.conf
@@ -23,6 +23,19 @@ set_real_ip_from 2a06:98c0::/29;
 real_ip_header CF-Connecting-IP;
 
 
+geo $limited_ip {
+    default      1;
+    127.0.0.1    0;
+}
+
+map $limited_ip $limited_ip_key {
+    0 '';
+    1 $binary_remote_addr;
+}
+
+limit_req_zone $limited_ip zone=apilimit:10m rate=10r/s;
+
+
 upstream backend  {
 {% for number in range(1, uwsgi_n+1, 1) %}  server unix:/var/www/echaloasuerte/echaloasuerte-uwsgi{{ number }}.sock;
 {% endfor %}
@@ -93,6 +106,7 @@ server {
     }
 
     location /api/v1/ {
+        limit_req zone=apilimit burst=20;
         proxy_set_header Host $http_host;
         proxy_pass http://old-backend-frontend;
     }
@@ -115,6 +129,7 @@ server {
     }
 
     location /api {
+        limit_req zone=apilimit burst=20;
         include         uwsgi_params;
         uwsgi_pass      backend-echaloasuerte-3;
     }


### PR DESCRIPTION
Use NGINX limit_req module to configure a zone used
on /api locations, to set a rate limit of 2 requests
per second for a given IP. This excludes requests from
127.0.0.1.